### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/controllers/dashboards_controller_spec.rb
+++ b/spec/controllers/dashboards_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DashboardsController, :type => :controller do
   describe "GET #show" do
     it "returns http success" do
       get :show
-      expect(response).to have_http_status(:success)
+      expect(response).to be_successful
     end
   end
 end


### PR DESCRIPTION
> DEPRECATION WARNING: The success? predicate is deprecated and will be removed
> in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers.