### PR TITLE
Add ES6 support to Uglifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(:harmony => true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Without this we're getting

> Uglifier::Error: Unexpected token: punc ({). To use ES6 syntax, harmony mode
> must be enabled with Uglifier.new(:harmony => true).

when precompiling assets on Heroku.