### PR TITLE
Add script to remove Devise

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 5. `rm -rf .git .circleci`
 6. Replace all occurrences of "Boilerplate" with YourAppName": `find . -type f -print0 | xargs -0 sed -i '' 's/Boilerplate/YourAppName/g'`
 7. Replace all occurrences of "boilerplate" with "your_app_name": `find . -type f -print0 | xargs -0 sed -i '' 's/boilerplate/your_app_name/g'`
-8. `echo "# README" > README.md`
+8. If you don't need users in the project, remove Devise: `script/boilerplate/remove_devise`
+9. `echo "# README" > README.md`
+10. `rm -rf script/boilerplate`
 
 ... and you're off to the races.
 

--- a/script/boilerplate/remove_devise
+++ b/script/boilerplate/remove_devise
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+git rm -rf app/views/devise
+git rm app/models/user.rb
+git rm config/initializers/devise.rb
+git rm config/locales/devise.en.yml
+git rm db/migrate/20170511143819_devise_create_users.rb
+git rm spec/factories/users.rb
+git rm spec/models/user_spec.rb
+
+git commit -am "Remove Devise"


### PR DESCRIPTION
We occasionally run into the rare exception where we don't actually need Devise.
This script allows us to easily remove it from the freshly initiated project.