### PR TITLE
Upgrade PostgreSQL to 10.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-       - image: circleci/postgres:9.6
+       - image: circleci/postgres:10.6
          environment:
          - POSTGRES_USER=ubuntu
     working_directory: ~/repo


### PR DESCRIPTION
PostgreSQL 10 is widely available, and in particular; available on Heroku, which
makes it a good target for future applications.