### PR TITLE
Bump Ruby to 2.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.6-node
+       - image: circleci/ruby:2.6.1-node
          environment:
          - PG_HOST=localhost
          - PG_USER=ubuntu

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "2.6.0"
+ruby "2.6.1"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")


### PR DESCRIPTION
CI was using 2.6.1 anyways, because of the relaxed "2.6"-specifier.