### PR TITLE
Match Rubocop config to the one from our dotfiles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Layout/SpaceInsideHashLiteralBraces:
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - "spec/**/*"
+    - 'spec/**/*'
 
 Metrics/AbcSize:
   Exclude:
@@ -57,8 +57,8 @@ Metrics/ClassLength:
 
 Metrics/LineLength:
   Exclude:
-    - "app/dashboards/*"
-    - "config/initializers/*"
+    - 'app/dashboards/*'
+    - 'config/initializers/*'
     - 'db/migrate/*'
 
 Metrics/MethodLength:


### PR DESCRIPTION
... not entirely sure why these have grown apart, but I reckon the dotfiles ones
is the proper.