### PR TITLE
Don't indent array based on their bracket position (#7)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Layout/DotPosition:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
+Layout/IndentArray:
+  EnforcedStyle: consistent
+
 Layout/IndentHash:
   EnforcedStyle: consistent
 


### PR DESCRIPTION
This causes way too much busywork trying to align things to the middle of the
line.

Prefer:

    expect(enquiry.possible_states).to eq([
      Enquiry::AWAITING_REPLY,
      Enquiry::BOOKED,
      Enquiry::NOT_BOOKED,
      Enquiry::REJECTED
    ])

Over:

    expect(enquiry.possible_states).to eq([
                                            Enquiry::AWAITING_REPLY,
                                            Enquiry::BOOKED,
                                            Enquiry::NOT_BOOKED,
                                            Enquiry::REJECTED
                                          ])

See also https://github.com/substancelab/dotfiles/pull/7