### PR TITLE
Remove Ruby Sass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "rails-i18n"
 gem "devise"
 
 # Frontend
-gem "sass-rails"
 gem "simple_form"
 gem "slim-rails"
 gem "turbolinks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,17 +230,6 @@ GEM
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
-    sass (3.5.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -320,7 +309,6 @@ DEPENDENCIES
   rails-i18n
   rspec-rails
   rubocop
-  sass-rails
   selenium-webdriver
   shoulda-matchers
   simple_form
@@ -337,4 +325,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
We're building our assets with node-sass these days, so we probably don't need
sass support in Sprockets anymore.