### PR TITLE
Lock down web-console to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere
   # in the code.
   gem "listen"
-  gem "web-console"
+  gem "web-console", "< 4.0"
 
   # Run stuff automatically
   gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,7 +321,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier
-  web-console
+  web-console (< 4.0)
   webpacker
 
 RUBY VERSION


### PR DESCRIPTION
V4 drops support for Rails 5, so upgrading to web-console 4.x is an implicit
upgrade to Rails 6 as well; a step we (nor rails) aren't quite ready to take
yet.

See https://github.com/rails/web-console/blob/master/CHANGELOG.markdown#400 for details, or https://github.com/substancelab/rails-boilerplate/pull/260 for what happens on upgrade.