### PR TITLE
Use RSpec version with support for Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem "dotenv-rails"
 
   gem "factory_bot_rails"
-  gem "rspec-rails"
+  gem "rspec-rails", ">= 4.0.0.beta2"
   gem "shoulda-matchers"
 
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,23 +202,23 @@ GEM
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-rails (3.8.2)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+    rspec-rails (4.0.0.beta2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.8)
+      rspec-expectations (~> 3.8)
+      rspec-mocks (~> 3.8)
+      rspec-support (~> 3.8)
+    rspec-support (3.8.2)
     rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -307,7 +307,7 @@ DEPENDENCIES
   puma
   rails
   rails-i18n
-  rspec-rails
+  rspec-rails (>= 4.0.0.beta2)
   rubocop
   rubocop-performance
   selenium-webdriver


### PR DESCRIPTION
Works around failures on Rails 6:

    Failure/Error:
       get :show,
           :params => {:id => person.to_param},
           :session => valid_session

     ActionView::Template::Error:
       wrong number of arguments (given 2, expected 1)
     # ./spec/controllers/people_controller_spec.rb:27:in `block (3 levels) in <main>'
     # ./spec/support/database_cleaner.rb:13:in `block (3 levels) in <main>'
     # ./spec/support/database_cleaner.rb:12:in `block (2 levels) in <main>'
     # ------------------
     # --- Caused by: ---
     # ArgumentError:
     #   wrong number of arguments (given 2, expected 1)
     #   ./spec/controllers/people_controller_spec.rb:27:in `block (3 levels) in <main>'