### PR TITLE
Configure Dependabot via code

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    version_requirement_updates: "increase_versions_if_necessary"
+  # Keep Ruby gems up to date
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "daily"
+    version_requirement_updates: "increase_versions_if_necessary"


### PR DESCRIPTION
This should ensure a consistent setup for newly created projects. I am not entirely sure if we still have to manually add the repository to Dependabot, though.