### PR TITLE
Ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ config/database.yml
 /public/packs-test
 /yarn-error.log
 yarn-debug.log*
+
+# Environment files
+.env.*.local
+.env.local


### PR DESCRIPTION
Following the recommendations from
https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use.