### PR TITLE
Allow web-console to upgrade freely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere
   # in the code.
   gem "listen"
-  gem "web-console", "<= 4.0.1"
+  gem "web-console"
 
   # Run stuff automatically
   gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier
-  web-console (<= 4.0.1)
+  web-console
   webpacker
 
 RUBY VERSION


### PR DESCRIPTION
I can't see a reason to keep the version lock any longer; it seems to be a
leftover from when we were on Rails 5 and web-console 4.0+ meant Rails 6.