### PR TITLE
Upgrade ruby to 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.5-node
+      - image: circleci/ruby:2.7.0-node
         environment:
         - DATABASE_URL=postgres://ubuntu:@localhost:5432/circle_test
 

--- a/.circleci/config.yml.example
+++ b/.circleci/config.yml.example
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.6.5-node
+      - image: circleci/ruby:2.7.0-node
         environment:
         - DATABASE_URL=postgres://ubuntu:@localhost:5432/circle_test
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'vendor/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "2.6.5"
+ruby "2.7.0"
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,7 +345,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.6.5p114
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.0.2
+   2.1.2

--- a/README_APP.md
+++ b/README_APP.md
@@ -2,7 +2,7 @@
 
 ## System dependencies
 
-* Ruby 2.6 (see `Gemfile`)
+* Ruby 2.7 (see `Gemfile`)
 * PostgreSQL 11.x (and `libpq-dev` or equivalent)
 * Node 11.x <https://nodejs.org/en/download/package-manager/>
 * Yarn 1.x <https://yarnpkg.com/en/docs/install#linux-tab>


### PR DESCRIPTION
Note: This upgrade gives a long list of gems related warnings when running specs:
>/home/olepalm/.rvm/gems/ruby-2.7.0/gems/tzinfo-1.2.5/lib/tzinfo/ruby_core_support.rb:142: warning: Using the last argument as keyword parameters is deprecated
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/tzinfo-1.2.5/lib/tzinfo/ruby_core_support.rb:142: warning: Using the last argument as keyword parameters is deprecated
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionpack-6.0.2.1/lib/action_dispatch/middleware/stack.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionpack-6.0.2.1/lib/action_dispatch/middleware/static.rb:110: warning: The called method `initialize' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/type.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call     
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/type/adapter_specific_registry.rb:9: warning: The called method `add_modifier' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/type/integer.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/type/value.rb:8: warning: The called method `initialize' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/connection_adapters/postgresql/oid/specialized_string.rb:12: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/type/value.rb:8: warning: The called method `initialize' is defined here

> Randomized with seed 11495
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/connection_adapters/abstract/transaction.rb:145: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/connection_adapters/abstract/transaction.rb:78: warning: The called method `initialize' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/devise-4.7.1/lib/devise/test/controller_helpers.rb:35: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call 
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionpack-6.0.2.1/lib/action_controller/test_case.rb:457: warning: The called method `process' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionview-6.0.2.1/lib/action_view/view_paths.rb:11: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call   
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionview-6.0.2.1/lib/action_view/lookup_context.rb:140: warning: The called method `template_exists?' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionview-6.0.2.1/lib/action_view/unbound_template.rb:24: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/actionview-6.0.2.1/lib/action_view/template.rb:130: warning: 
The called method `initialize' is defined here
./home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/naming.rb:206: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call   
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `translate' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/translation.rb:67: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call/home/olepalm/.rvm/gems/ruby-2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `translate' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/errors.rb:500: warning: 
Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call    
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `translate' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/errors.rb:514: warning: 
Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call    
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `translate' is defined here
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activerecord-6.0.2.1/lib/active_record/attribute_methods/dirty.rb:102: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/olepalm/.rvm/gems/ruby-2.7.0/gems/activemodel-6.0.2.1/lib/active_model/attribute_mutation_tracker.rb:45: warning: The called method `changed?' is defined here
