### PR TITLE
Looks like we need a password going forward

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
       - image: circleci/postgres:latest-ram
         environment:
         - POSTGRES_USER=ubuntu
+        - POSTGRES_PASSWORD=totallysecret
     working_directory: ~/repo
 
     steps:

--- a/.circleci/config.yml.example
+++ b/.circleci/config.yml.example
@@ -16,6 +16,7 @@ jobs:
       - image: circleci/postgres:latest-ram
         environment:
         - POSTGRES_USER=ubuntu
+        - POSTGRES_PASSWORD=totallysecret
     working_directory: ~/repo
 
     steps:


### PR DESCRIPTION
CI builds have started failing with

    Error: Database is uninitialized and superuser password is not specified.
           You must specify POSTGRES_PASSWORD to a non-empty value for the
           superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

           You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
           connections without a password. This is *not* recommended.

           See PostgreSQL documentation about "trust":
           https://www.postgresql.org/docs/current/auth-trust.html

    Exited with code 1

Presumably something changed on Circle CI, perhaps in the PostgreSQL image or
version.