### PR TITLE
Remove more superfluous directives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,9 +50,6 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
 Metrics/AbcSize:
   Exclude:
     - 'db/migrate/*'
@@ -84,9 +81,6 @@ Style/BlockDelimiters:
 
 Style/Documentation:
   Enabled: false
-
-Style/HashEachMethods:
-  Enabled: true
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets


### PR DESCRIPTION
These should have been removed as part of fca834e with the same
reasoning as there.