### PR TITLE
Force a rebuild of all gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+          - v2-dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-dependencies-
 
       - run:
           name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
           paths:
             - ./vendor/bundle
             - ./node_modules
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+          key: v2-dependencies-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
 
       # Database setup
       - run:


### PR DESCRIPTION
Should fix
https://app.circleci.com/pipelines/github/substancelab/rails-boilerplate/466/workflows/c6444d88-3f3a-4809-8eb1-1f7587827aea/jobs/1604:

> LoadError: libffi.so.6: cannot open shared object file: No such file
> or directory - /home/circleci/repo/vendor/bundle/ruby/3.0.0/gems/ffi-1.15.0/lib/ffi_c.so