### PR TITLE
Remove unused gems from the bundle before caching

### DIFF
--- a/.circleci/config.yml.example
+++ b/.circleci/config.yml.example
@@ -44,6 +44,7 @@ jobs:
             gem install bundler
             bundle update --bundler
             bundle install --jobs=4 --retry=3 --path="./vendor/bundle"
+            bundle clean --force
             yarn install --check-files
 
       - save_cache:


### PR DESCRIPTION
Our caches tend to grow ever larger, taking ever more time to create and
restore, because we keep installing gems and never remove the unused
ones.