### PR TITLE
Switch to modern Circle CIs images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:3.0.2-node
+      - image: cimg/ruby:3.0.2-node
         environment:
         - DATABASE_URL=postgres://ubuntu:@localhost:5432/circle_test
 


### PR DESCRIPTION
Circle CI says:

> Legacy images with the prefix "circleci/" will be deprecated on
> December 31, 2021. For faster builds, upgrade your projects with
> next-generation convenience images.

- https://circleci.com/docs/2.0/circleci-images/