### PR TITLE
Don't worry about offenses in generated migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'config/initializers/content_security_policy.rb'
     - 'config/initializers/wrap_parameters.rb'
     - 'config/puma.rb'
+    - 'db/migrate/*.active_storage.rb'
     - 'db/schema.rb'
     - 'lib/templates/**/*.rb'
     - 'node_modules/**/*'


### PR DESCRIPTION
ActiveStorage maintains their own tables in the database by generating the occasional migration. All of those generated migrations are affixed with .active_storage.rb and for some reason they don't seem to adhere to our coding guidelines ;)