### PR TITLE
Add net-* gems back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "turbolinks"
 gem "webpacker", "6.0.0.rc6"
 
 # Integrations
+gem "net-imap"
 gem "net-pop"
 gem "net-smtp"
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "turbolinks"
 gem "webpacker", "6.0.0.rc6"
 
 # Integrations
+gem "net-pop"
 gem "net-smtp"
 
 # Assets management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
     msgpack (1.4.2)
     multi_json (1.13.1)
     nenv (0.3.0)
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.2)
       io-wait
       timeout
@@ -348,6 +352,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   listen
+  net-pop
   net-smtp
   postgresql
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,10 @@ GEM
     msgpack (1.4.2)
     multi_json (1.13.1)
     nenv (0.3.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
     net-pop (0.1.1)
       digest
       net-protocol
@@ -305,6 +309,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.1)
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.10)
@@ -352,6 +357,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   listen
+  net-imap
   net-pop
   net-smtp
   postgresql


### PR DESCRIPTION
It was removed from stdlib in Ruby 3.1, and it seems we still need it for the mail gem.