### PR TITLE
Bump multi_json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     msgpack (1.5.4)
-    multi_json (1.13.1)
+    multi_json (1.15.0)
     nenv (0.3.0)
     net-imap (0.2.3)
       digest


### PR DESCRIPTION
Fixes an issue running guard-livereload:

> 09:51:17 - INFO - Guard is now watching at '/Users/jakob/Projects/FlexFabrikken/Worklab/worklab'
> [1] guard(main)> 09:51:21 - INFO - Browser connected.
> 09:51:21 - ERROR - tried to create Proc object without a block
> #<Thread:0x0000000109235438 /Users/jakob/.rvm/gems/ruby-3.1.2/gems/guard-livereload-2.5.2/lib/guard/livereload/reactor.rb:11 run> terminated with exception (report_on_exception is true):
> /Users/jakob/.rvm/gems/ruby-3.1.2/gems/multi_json-1.13.1/lib/multi_json/options_cache.rb:12:in
> `new': tried to create Proc object without a block (ArgumentError)