### PR TITLE
Remove Sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "postcss-smart-import": "^0.7.6",
     "precss": "^4.0.0",
     "resolve-url-loader": "^5.0.0",
-    "sass": "^1.54.4",
-    "sass-loader": "^13.0.2",
     "standard": "^17.0.0",
     "style-loader": "^3.3.1",
     "webpack": "^5.53.0",


### PR DESCRIPTION
If we need it going forward we'll have to install it, but right now, it looks like Tailwind is the more likely future.