### PR TITLE
Verify that we can eager load code

### DIFF
--- a/.circleci/config.yml.example
+++ b/.circleci/config.yml.example
@@ -77,6 +77,13 @@ jobs:
           command: |
             bundle exec rubocop
 
+      - run:
+          name: Zeitwerk compatibility
+          command: |
+            bundle exec rails zeitwerk:check
+          environment:
+            EAGER_LOAD: true
+
       # collect reports
       - store_test_results:
           path: /tmp/test-results

--- a/README_APP.md
+++ b/README_APP.md
@@ -17,6 +17,7 @@
 The following environment variables are expected to be configured by the environment, not via .env files:
 
 * `DOMAIN`: Domain name that the application is being served at.
+* `EAGER_LOAD`: Set this to `"true"` to force eager loading in development.
 * `EMAIL_SENDER`: Email address to use as the from address when sending emails.
 * `PORT`: The port Puma listens on (defaults to `3000`).
 * `RAILS_ENV`: The environment to run the application in (defaults to `development`).

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = ENV["EAGER_LOAD"] == "true"
 
   # Show full error reports.
   config.consider_all_requests_local = true


### PR DESCRIPTION
We've unfortunately deployed a file to production on a project that couldn't be eager loaded, which broke the entire application, even though nothing in development and CI warned us.

This is a step towards catching problems like the below, which would otherwise only occur on boot in production mode:

    Hold on, I am eager loading the application.
    rake aborted!
    NameError: uninitialized constant Form::InputGroup::Component
 
       class DateComponent < Form::InputGroup::Component
                                              ^^^^^^^^^^^
    Did you mean?  Complex
    ~/frontlobby/app/components/tailwind_ui/application_ui/form/input_group/date_component.rb:5:in
    `<module:InputGroup>'

This also gives us a fine opportunity to check everything for compatiblity with Zeitwerk.