### PR TITLE
Upgrade bundler to 2.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,4 +380,4 @@ RUBY VERSION
    ruby 3.1.2
 
 BUNDLED WITH
-   2.2.32
+   2.4.4


### PR DESCRIPTION
Primarily to get rid of

> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name =>
> spell_checker)' has been deprecated. Please call
> `DidYouMean.correct_error(error_name, spell_checker)' instead.