### PR TITLE
Use ApplicationMailer as parent for Devise::Mailer

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   # config.mailer = 'Devise::Mailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = "ApplicationMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and


### PR DESCRIPTION
This way all our mailers inherit from the same parent, which seems like a good practice with fewer surprises.