### PR TITLE
Use the newest bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,4 +390,4 @@ RUBY VERSION
    ruby 3.2.2
 
 BUNDLED WITH
-   2.4.4
+   2.4.13


### PR DESCRIPTION
This restores our ability to use caches on Circle CI because we no longer update the bundler version during the build which would change the cache keys, resulting in both these happening in the same build:

> No cache is found for key:  v2-dependencies-VfUsQdg7ZsZuJ7MoXZYjq8KDNuCrinCflbBCC33t_K8=-a7uV79TxB+R2O97bXOKkchW+chIDbbCGuYoEQ7kTm2o=
> ...
> Skipping cache generation, cache already exists for key: v2-dependencies-lOI9Cs0dEuq6mIt_QO6uLzJduGlmoSajBZuSsQ4vXD8=-a7uV79TxB+R2O97bXOKkchW+chIDbbCGuYoEQ7kTm2o=
