### PR TITLE
Use orbs to install Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@5.1.0
+
 jobs:
   build:
     docker:
@@ -22,13 +26,12 @@ jobs:
       - checkout
 
       - run:
-          name: "Install specified version of Node.js and npm"
+          name: "Configure Node version"
           command: |
-            export WANTED_NODE_VERSION=`grep nodejs .tool-versions | cut -d " " -f 2`
-            echo $WANTED_NODE_VERSION
-            curl -sSL "https://nodejs.org/dist/v${WANTED_NODE_VERSION}/node-v${WANTED_NODE_VERSION}-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v${WANTED_NODE_VERSION}-linux-x64/bin/node
-            curl https://www.npmjs.com/install.sh | sudo bash
-            node -v
+            grep nodejs .tool-versions | cut -d " " -f 2 > .nvmrc
+
+      - node/install:
+          install-yarn: true
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml.example
+++ b/.circleci/config.yml.example
@@ -2,7 +2,11 @@
 #
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@5.1.0
+
 jobs:
   build:
     docker:
@@ -22,13 +26,12 @@ jobs:
       - checkout
 
       - run:
-          name: "Install specified version of Node.js and npm"
+          name: "Configure Node version"
           command: |
-            export WANTED_NODE_VERSION=`grep nodejs .tool-versions | cut -d " " -f 2`
-            echo $WANTED_NODE_VERSION
-            curl -sSL "https://nodejs.org/dist/v${WANTED_NODE_VERSION}/node-v${WANTED_NODE_VERSION}-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v${WANTED_NODE_VERSION}-linux-x64/bin/node
-            curl https://www.npmjs.com/install.sh | sudo bash
-            node -v
+            grep nodejs .tool-versions | cut -d " " -f 2 > .nvmrc
+
+      - node/install:
+          install-yarn: true
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Circle CIs node orb uses .nvmrc to determine the version of Node to install, if one hasn't explicitly been specified using `node-version`.

However, we use .tool-versions to specify the version of Node to use, so we have to manually extract the version from that file and write it to .nvmrc for the orb to use.

See https://circleci.com/developer/orbs/orb/circleci/node for details.