### PR TITLE
Upgrade NodeJS to 20.9.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 18.17.0
+nodejs 20.9.0
 yarn 1.22.19

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 16.20.2
+nodejs 18.17.0
 yarn 1.22.19


### PR DESCRIPTION
18.17.0 is the currently recommended LTS version of NodeJS.

Depends on #1273 