### PR TITLE
Add default housekeeping routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,14 @@ Rails.application.routes.draw do
   devise_for :users
   resource :dashboard, :only => [:show]
 
+  # Reveal health status on /up that returns 200 if the app boots with no
+  # exceptions, otherwise 500. Can be used by load balancers and uptime monitors
+  # to verify that the app is live.
+  get "up" => "rails/health#show", :as => :rails_health_check
+
+  # Render dynamic PWA files from app/views/pwa/*
+  get "service-worker" => "rails/pwa#service_worker", :as => :pwa_service_worker
+  get "manifest" => "rails/pwa#manifest", :as => :pwa_manifest
+
   root :to => "dashboards#show"
 end


### PR DESCRIPTION
Add default routes for health check and PWA files. These are default in Rails 7.2+ and can be removed if not needed.