### PR TITLE
Ignore pids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !/tmp/.keep
 
 # Ignore pidfiles, but keep the directory.
+/pids/*
 /tmp/pids/*
 !/tmp/pids/
 !/tmp/pids/.keep


### PR DESCRIPTION
It looks like something is still creating pids in the root directory, perhaps procodile? We don't want to track those in git.