### PR TITLE
Use configured domain as a canonical host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "postgresql"
 
 # App serving
 gem "puma"
+gem "rack-canonical-host"
 
 gem "rails-i18n"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-canonical-host (1.3.0)
+      addressable (> 0, < 3)
+      rack (>= 1.6, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -405,6 +408,7 @@ DEPENDENCIES
   net-smtp
   postgresql
   puma
+  rack-canonical-host
   rails (<= 7.2.1.1)
   rails-i18n
   rspec-rails (>= 4.0.0.beta2)

--- a/README_APP.md
+++ b/README_APP.md
@@ -16,7 +16,7 @@
 
 The following environment variables are expected to be configured by the environment, not via .env files:
 
-* `DOMAIN`: Domain name that the application is being served at.
+* `DOMAIN`: Domain name that the application is being served at. All requests for other domains will be redirected to this domain.
 * `EAGER_LOAD`: Set this to `"true"` to force eager loading in development.
 * `EMAIL_SENDER`: Email address to use as the from address when sending emails.
 * `PORT`: The port Puma listens on (defaults to `3000`).

--- a/config.ru
+++ b/config.ru
@@ -4,5 +4,14 @@
 
 require_relative "config/environment"
 
+# Redirect to the single hostname that we want to use for all requests
+require "rack/canonical_host"
+if ENV["DOMAIN"]
+  use \
+    Rack::CanonicalHost,
+    ENV["DOMAIN"],
+    :cache_control => "max-age=3600"
+end
+
 run Rails.application
 Rails.application.load_server


### PR DESCRIPTION
All requests for other domains will be redirected to this domain.